### PR TITLE
DM-38279: Clean up headers sent with lab controller requests

### DIFF
--- a/src/rsp_restspawner/errors.py
+++ b/src/rsp_restspawner/errors.py
@@ -20,3 +20,7 @@ class MissingFieldError(Exception):
 
 class EventError(Exception):
     pass
+
+
+class InvalidAuthStateError(Exception):
+    """The JupyterHub auth state for the user contains no token."""

--- a/src/rsp_restspawner/util.py
+++ b/src/rsp_restspawner/util.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import yaml
 
-from .constants import DEFAULT_ADMIN_TOKEN_FILE, DEFAULT_CONFIG_FILE
+from .constants import DEFAULT_CONFIG_FILE
 
 
 def to_camel_case(string: str) -> str:
@@ -35,16 +35,6 @@ def get_config() -> Dict[str, Any]:
     config_file = os.getenv("RESTSPAWNER_CONFIG_FILE", DEFAULT_CONFIG_FILE)
     with open(config_file) as f:
         return yaml.safe_load(f)
-
-
-def get_admin_token() -> str:
-    """Returns the admin token, read from a file (usually mounted as a
-    secret)."""
-    token_file = os.getenv(
-        "RESTSPAWNER_ADMIN_TOKEN_FILE", DEFAULT_ADMIN_TOKEN_FILE
-    )
-    with open(token_file, "r") as f:
-        return f.read().strip()
 
 
 def get_external_instance_url() -> str:


### PR DESCRIPTION
Rework how the headers are constructed when sending requests to be a bit more obvious about whether the request is authenticated with the user token or the admin token. Stop sending Content-Type headers with requests with no body; this is arguably an HTTP protocol error. Use the admin token for the poll route, since I believe it needs it, rather than trying to use the user's token.