### PR TITLE
DM-38279: Pin JupyterHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyterhub/jupyterhub:3.1.0 as base-image
+FROM jupyterhub/jupyterhub:3.1.1 as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -7,9 +7,12 @@
 # After editing, update requirements/main.txt by running:
 #     make update-deps
 
+# We want to explicitly control new versions of JupyterHub. Pin this to the
+# same version that Dockerfile uses.
+jupyterhub==3.1.1
+
 # Dependencies used directly by the code added by this package.
 httpx
-jupyterhub
 pydantic
 PyYAML
 


### PR DESCRIPTION
Pin the version of JupyterHub to the same version that is used as the base image for the Docker build.