### PR TITLE
DM-38279: Refactor GafaelfawrAuthenticator

### DIFF
--- a/src/rsp_restspawner/__init__.py
+++ b/src/rsp_restspawner/__init__.py
@@ -1,3 +1,4 @@
+from .auth import GafaelfawrAuthenticator
 from .spawner import RSPRestSpawner
 
-__all__ = ["RSPRestSpawner"]
+__all__ = ["GafaelfawrAuthenticator", "RSPRestSpawner"]

--- a/src/rsp_restspawner/auth.py
+++ b/src/rsp_restspawner/auth.py
@@ -1,5 +1,8 @@
-"""Authenticator for the Nublado 3 instantiation of JupyterHub."""
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+"""Gafaelfawr authenticator for JupyterHub."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
 
 from jupyterhub.app import JupyterHub
 from jupyterhub.auth import Authenticator
@@ -7,68 +10,55 @@ from jupyterhub.handlers import BaseHandler, LogoutHandler
 from jupyterhub.user import User
 from jupyterhub.utils import url_path_join
 from tornado.httputil import HTTPHeaders
-from tornado.web import RequestHandler
+from tornado.web import HTTPError, RequestHandler
 
-Route = Tuple[str, Type[BaseHandler]]
-AuthState = Dict[str, Any]
+AuthInfo = dict[str, str | dict[str, str]]
+Route = tuple[str, type[BaseHandler]]
 
 
-async def _build_auth_info(headers: HTTPHeaders) -> AuthState:
-    """Construct the authentication information for a user.  This is
-    simplified from the Nublado v2 implementation, because the Hub has a lot
-    less to do with the information it gets.
+def _build_auth_info(headers: HTTPHeaders) -> AuthInfo:
+    """Construct the authentication information for a user.
 
-    Retrieve the token from the headers, and build an auth info dict
-    in the format expected by JupyterHub.  We don't need to do
-    anything with the token other than call the REST JupyterLab
-    controller API, because the JupyterLab controller handles all the
-    details of deciding what to do with it.
-
-    Except, hmmm, I think we do need a username to make the Hub happy.
-
-    This is in a separate method so that it can be unit-tested.
+    Gafaelfawr puts the username in ``X-Auth-Request-User`` and the delegated
+    notebook token in ``X-Auth-Request-Token``. Use those headers to construct
+    a valid JupyterHub ``auth_state``.
     """
-    token = headers.get("X-Auth-Request-Token")
     username = headers.get("X-Auth-Request-User")
+    token = headers.get("X-Auth-Request-Token")
+    if not username or not token:
+        raise HTTPError(401, "User is not authenticated")
     return {"name": username, "auth_state": {"token": token}}
 
 
-#
-# The rest of this file ought to ultimately come from a separate python
-# module that we just import.
-#
-
-
 class GafaelfawrAuthenticator(Authenticator):
-    """JupyterHub authenticator using Gafaelfawr headers.  This is straight
-    from Nublado v2.
+    """JupyterHub authenticator using Gafaelfawr headers.
 
     Rather than implement any authentication logic inside of JupyterHub,
     authentication is done via an ``auth_request`` handler made by the NGINX
-    ingress controller.  JupyterHub then only needs to read the authentication
+    ingress controller. JupyterHub then only needs to read the authentication
     results from the headers of the incoming request.
 
     Normally, the authentication flow for JupyterHub is to send the user to
-    ``/hub/login`` and display a login form.  The submitted values to the form
+    ``/hub/login`` and display a login form. The submitted values to the form
     are then passed to the ``authenticate`` method of the authenticator, which
     is responsible for returning authentication information for the user.
     That information is then stored in an authentication session and the user
     is redirected to whatever page they were trying to go to.
 
     We however do not want to display an interactive form, since the
-    authentication information is already present in the headers.  We just
-    need JupyterHub to read it.
+    authentication information is already present in the headers. We just need
+    JupyterHub to read it.
 
     The documented way to do this is to register a custom login handler on a
     new route not otherwise used by JupyterHub, and then enable the
-    ``auto_login`` setting on the configured authenticator.  This setting
-    tells the built-in login page to, instead of presenting a login form,
-    redirect the user to whatever URL is returned by ``login_url``.  In our
-    case, this will be ``/hub/gafaelfawr/login``, served by the
-    `GafaelfawrLoginHandler` defined below.  This simple handler will read the
-    token from the header, retrieve its metadata, create the session and
-    cookie, and then make the same redirect call the login form handler would
-    normally have made after the ``authenticate`` method returned.
+    ``auto_login`` setting on the configured authenticator. This setting tells
+    the built-in login page to, instead of presenting a login form, redirect
+    the user to whatever URL is returned by ``login_url``. In our case, this
+    will be ``/hub/gafaelfawr/login``, served by `GafaelfawrLoginHandler`.
+    This simple handler will read the token from the header, retrieve its
+    metadata, create the session and cookie, and then make the same redirect
+    call the login form handler would normally have made after the
+    ``authenticate`` method returned.
 
     In this model, the ``authenticate`` method is not used, since the login
     handler never receives a form submission.
@@ -79,9 +69,9 @@ class GafaelfawrAuthenticator(Authenticator):
     JupyterHub code would be to not override ``login_url``, set
     ``auto_login``, and then override ``get_authenticated_user`` in the
     authenticator to read authentication information directly from the request
-    headers.  It looks like an authenticator configured in that way would
+    headers. It looks like an authenticator configured in that way would
     authenticate the user "in place" in the handler of whatever page the user
-    first went to, without any redirects.  This would be slightly more
+    first went to, without any redirects. This would be slightly more
     efficient and the code appears to handle it, but the current documentation
     (as of 1.5.0) explicitly says to not override ``get_authenticated_user``.
 
@@ -105,19 +95,16 @@ class GafaelfawrAuthenticator(Authenticator):
         # most recent token and group information.
         self.refresh_pre_spawn = True
 
-        #
-        self.auth_data: Optional[AuthState] = None
-
     async def authenticate(
-        self, handler: RequestHandler, data: Dict[str, str]
-    ) -> Optional[Union[str, Dict[str, Any]]]:
+        self, handler: RequestHandler, data: dict[str, str]
+    ) -> str | dict[str, Any] | None:
         """Login form authenticator.
 
         This is not used in our authentication scheme.
         """
         raise NotImplementedError()
 
-    def get_handlers(self, app: JupyterHub) -> List[Route]:
+    def get_handlers(self, app: JupyterHub) -> list[Route]:
         """Register the header-only login and the logout handlers."""
         return [
             ("/gafaelfawr/login", GafaelfawrLoginHandler),
@@ -135,30 +122,36 @@ class GafaelfawrAuthenticator(Authenticator):
 
     async def refresh_user(
         self, user: User, handler: Optional[RequestHandler] = None
-    ) -> Union[bool, AuthState]:
+    ) -> bool | AuthInfo:
         """Optionally refresh the user's token."""
         # If running outside of a Tornado handler, we can't refresh the auth
         # state, so assume that it is okay.
         if not handler:
             return True
 
-        # If there is no X-Auth-Request-Token header, this request did
-        # not go through the Hub ingress and thus is coming from
-        # inside the cluster, such as requests to JupyterHub from a
-        # JupyterLab instance.  Allow JupyterHub to use its normal
-        # authentication logic
+        # If there is no X-Auth-Request-Token header, this request did not go
+        # through the Hub ingress and thus is coming from inside the cluster,
+        # such as requests to JupyterHub from a JupyterLab instance. Allow
+        # JupyterHub to use its normal authentication logic.
         token = handler.request.headers.get("X-Auth-Request-Token")
         if not token:
             return True
 
-        # We have a new token.  If it doesn't match the token we have stored,
+        # JupyterHub doesn't support changing the username of a user during
+        # refresh, so if the username doesn't match what we're expecting,
+        # raise a 401 error and force the user to reauthenticate. This can
+        # happen if the user's username was changed underneath us.
+        username = handler.request.headers.get("X-Auth-Request-User")
+        if not username or user.name != username:
+            raise HTTPError(401, "Username does not match expected identity")
+
+        # We have a new token. If it doesn't match the token we have stored,
         # replace the stored auth state with the new auth state.
         auth_state = await user.get_auth_state()
-        if token == auth_state["token"]:
-            # It does match, so it's still fine
+        if token == auth_state.get("token"):
             return True
         else:
-            return await _build_auth_info(handler.request.headers)
+            return _build_auth_info(handler.request.headers)
 
 
 class GafaelfawrLogoutHandler(LogoutHandler):
@@ -170,7 +163,7 @@ class GafaelfawrLogoutHandler(LogoutHandler):
 
     @property
     def shutdown_on_logout(self) -> bool:
-        """Unconditionally true for Gafaelfawr logout"""
+        """Unconditionally true for Gafaelfawr logout."""
         return True
 
     async def render_logout_page(self) -> None:
@@ -187,19 +180,19 @@ class GafaelfawrLoginHandler(BaseHandler):
 
     async def get(self) -> None:
         """Handle GET to the login page."""
-        auth_info = await _build_auth_info(self.request.headers)
+        auth_info = _build_auth_info(self.request.headers)
 
         # Store the ancillary user information in the user database and create
-        # or return the user object.  This call is unfortunately undocumented,
+        # or return the user object. This call is unfortunately undocumented,
         # but it's what BaseHandler calls to record the auth_state information
-        # after a form-based login.  Hopefully this is a stable interface.
+        # after a form-based login. Hopefully this is a stable interface.
         user = await self.auth_to_user(auth_info)
 
         # Tell JupyterHub to set its login cookie (also undocumented).
         self.set_login_cookie(user)
 
         # Redirect to the next URL, which is under the control of JupyterHub
-        # and opaque to the authenticator.  In practice, it will normally be
+        # and opaque to the authenticator. In practice, it will normally be
         # whatever URL the user was trying to go to when JupyterHub decided
         # they needed to be authenticated.
         self.redirect(self.get_next_url(user))

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -39,11 +39,11 @@ async def test_authenticator() -> None:
     # No headers, internal call, just return True and let JupyterHub do its
     # normal thing.
     assert await authenticator.refresh_user(MagicMock(), handler) is True
-    user = MagicMock()
-    user.get_auth_state = AsyncMock()
 
     # Token matches, return true.
+    user = MagicMock()
     user.name = "rachel"
+    user.get_auth_state = AsyncMock()
     user.get_auth_state.return_value = {"token": "token-of-affection"}
     assert await authenticator.refresh_user(user, handler) is True
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,0 +1,109 @@
+"""Tests for the Gafaelfawr authenticator.
+
+Most of the authenticator machinery is deeply entangled with JupyterHub and
+therefore can't be tested easily (and is also kept as simple as possible).
+This tests the logic that's sufficiently separable to run in a test harness.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from tornado import web
+from tornado.httputil import HTTPHeaders
+
+from rsp_restspawner.auth import (
+    GafaelfawrAuthenticator,
+    GafaelfawrLoginHandler,
+    GafaelfawrLogoutHandler,
+    _build_auth_info,
+)
+
+
+@pytest.mark.asyncio
+async def test_authenticator() -> None:
+    authenticator = GafaelfawrAuthenticator()
+    assert authenticator.get_handlers(MagicMock()) == [
+        ("/gafaelfawr/login", GafaelfawrLoginHandler),
+        ("/logout", GafaelfawrLogoutHandler),
+    ]
+
+    assert authenticator.login_url("/hub") == "/hub/gafaelfawr/login"
+
+    # No request, just return True.
+    assert await authenticator.refresh_user(MagicMock()) is True
+    handler = MagicMock()
+    handler.request.headers = HTTPHeaders()
+
+    # No headers, internal call, just return True and let JupyterHub do its
+    # normal thing.
+    assert await authenticator.refresh_user(MagicMock(), handler) is True
+    user = MagicMock()
+    user.get_auth_state = AsyncMock()
+
+    # Token matches, return true.
+    user.name = "rachel"
+    user.get_auth_state.return_value = {"token": "token-of-affection"}
+    assert await authenticator.refresh_user(user, handler) is True
+
+    # Token doesn't match, missing header, raise an error.
+    handler.request.headers = HTTPHeaders(
+        {"X-Auth-Request-Token": "token-of-affection"}
+    )
+    user.get_auth_state.return_value = {"token": "blahblahblah"}
+    with pytest.raises(web.HTTPError):
+        await authenticator.refresh_user(user, handler)
+
+    # Username doesn't match, raise an error. JupyterHub doesn't allow
+    # changing usernames in an authentication refresh, so we need to punt the
+    # user out entirely and force them to log in again.
+    handler.request.headers = HTTPHeaders(
+        {
+            "X-Auth-Request-User": "rachel",
+            "X-Auth-Request-Token": "token-of-affection",
+        }
+    )
+    user.name = "wrench"
+    with pytest.raises(web.HTTPError):
+        await authenticator.refresh_user(user, handler)
+
+    # Token doesn't match, proper headers, return the new auth state.
+    user.name = "rachel"
+    assert await authenticator.refresh_user(user, handler) == {
+        "name": "rachel",
+        "auth_state": {"token": "token-of-affection"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_login_handler() -> None:
+    """Test the core functionality of the login handler.
+
+    We unfortunately can't test it directly because mocking out the guts of
+    Tornado and JupyterHub is too tedious and fragile. But all the important
+    work happens in a helper function anyway.
+    """
+    with pytest.raises(web.HTTPError):
+        _build_auth_info(HTTPHeaders())
+
+    # One or the other header is missing.
+    headers = HTTPHeaders({"X-Auth-Request-User": "rachel"})
+    with pytest.raises(web.HTTPError):
+        _build_auth_info(headers)
+    headers = HTTPHeaders({"X-Auth-Request-Token": "token-of-affection"})
+    with pytest.raises(web.HTTPError):
+        _build_auth_info(headers)
+
+    # Test with proper headers.
+    headers = HTTPHeaders(
+        {
+            "X-Auth-Request-User": "rachel",
+            "X-Auth-Request-Token": "token-of-affection",
+        }
+    )
+    auth_state = _build_auth_info(headers)
+    assert auth_state == {
+        "name": "rachel",
+        "auth_state": {"token": "token-of-affection"},
+    }


### PR DESCRIPTION
Add error handling and tests to `GafaelfawrAuthenticator` and export it from the top level. At some point in the future we can reconsider whether it should be in a different package, but for now it's one of the primary exports of the package.

If the username changes during auth refresh, raise a 401 error rather than continuing. JupyterHub silently discards changes to the username, so we don't want to allow authentication to continue as the wrong user. (We ran into this problem when changing authentication providers from GitHub to CILogon and COmanage.)