### PR TITLE
DM-38279: Ignore keepalive messages from sse-starlette

### DIFF
--- a/src/rsp_restspawner/spawner.py
+++ b/src/rsp_restspawner/spawner.py
@@ -295,6 +295,9 @@ class RSPRestSpawner(Spawner):
                         msg = "Invalid progress value: {sse.data}"
                         self.log.error(msg)
                     continue
+                elif sse.event == "ping":
+                    # Sent by sse-starlette to keep the connection alive.
+                    continue
                 event = SpawnEvent.from_sse(sse, progress)
                 self._events.append(event)
                 if event.complete:

--- a/tests/support/controller.py
+++ b/tests/support/controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import respx
 from httpx import AsyncByteStream, Request, Response
@@ -49,6 +49,12 @@ class MockProgress(AsyncByteStream):
         yield b"\r\n"
 
         await asyncio.sleep(self._delay.total_seconds())
+
+        # sse-starlette sends these ping events periodically to keep the
+        # connection alive. We should just ignore them.
+        yield b"event: ping\r\n"
+        yield b"data: " + str(datetime.utcnow()).encode() + b"\r\n"
+        yield b"\r\n"
 
         yield b"event: progress\r\n"
         yield b"data: 45\r\n"


### PR DESCRIPTION
sse-starlette periodically sends ping events to keep the connection alive. Ignore those rather than reporting them to the user.