### PR TITLE
DM-38554: Use JSON progress messages

### DIFF
--- a/tests/spawner_test.py
+++ b/tests/spawner_test.py
@@ -122,14 +122,24 @@ async def test_progress_multiple(
 async def test_spawn_failure(
     spawner: RSPRestSpawner, mock_lab_controller: MockLabController
 ) -> None:
-    """Test error handling when a spawn fails."""
+    """Test error handling when a spawn fails.
+
+    Also tests invalid JSON in the event body. In those cases, the raw event
+    body should be treated as the message.
+    """
     mock_lab_controller.delay = timedelta(milliseconds=750)
     mock_lab_controller.fail_during_spawn = True
     user = spawner.user.name
     expected = [
         {"progress": 2, "message": "[info] Lab creation initiated"},
         {"progress": 45, "message": "[info] Pod requested"},
+        {"progress": 45, "message": "[unknown] This is not JSON"},
         {"progress": 45, "message": "[error] Something is going wrong"},
+        {"progress": 45, "message": '[info] {"invalid": "value"}'},
+        {
+            "progress": 45,
+            "message": '[info] {"message": "Blah", "progress": "Happy!"}',
+        },
         {
             "progress": 45,
             "message": f"[error] Some random failure for {user}",

--- a/tests/support/controller.py
+++ b/tests/support/controller.py
@@ -41,11 +41,8 @@ class MockProgress(AsyncByteStream):
         self._fail_during_spawn = fail_during_spawn
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
-        yield b"event: progress\r\n"
-        yield b"data: 2\r\n"
-        yield b"\r\n"
         yield b"event: info\r\n"
-        yield b"data: Lab creation initiated\r\n"
+        yield b'data: {"message": "Lab creation initiated", "progress": 2}\r\n'
         yield b"\r\n"
 
         await asyncio.sleep(self._delay.total_seconds())
@@ -56,27 +53,37 @@ class MockProgress(AsyncByteStream):
         yield b"data: " + str(datetime.utcnow()).encode() + b"\r\n"
         yield b"\r\n"
 
-        yield b"event: progress\r\n"
-        yield b"data: 45\r\n"
-        yield b"\r\n"
         yield b"event: info\r\n"
-        yield b"data: Pod requested\r\n"
+        yield b'data: {"message": "Pod requested", "progress": 45}\r\n'
         yield b"\r\n"
 
         await asyncio.sleep(self._delay.total_seconds())
 
         if self._fail_during_spawn:
-            yield b"event: error\r\n"
-            yield b"data: Something is going wrong\r\n"
+            yield b"event: blahblah\r\n"
+            yield b"data: This is not JSON\r\n"
             yield b"\r\n"
+
+            yield b"event: error\r\n"
+            yield b'data: {"message": "Something is going wrong"}\r\n'
+            yield b"\r\n"
+
+            yield b"event: info\r\n"
+            yield b'data: {"invalid": "value"}\r\n'
+            yield b"\r\n"
+
+            yield b"event: info\r\n"
+            yield b'data: {"message": "Blah", "progress": "Happy!"}\r\n'
+            yield b"\r\n"
+
             yield b"event: failed\r\n"
             msg = f"Some random failure for {self._user}"
-            yield b"data: " + msg.encode() + b"\r\n"
+            yield b'data: {"message": "' + msg.encode() + b'"}\r\n'
             yield b"\r\n"
         else:
             yield b"event: complete\r\n"
             msg = f"Pod successfully spawned for {self._user}"
-            yield b"data: " + msg.encode() + b"\r\n"
+            yield b'data: {"message": "' + msg.encode() + b'"}\r\n'
             yield b"\r\n"
 
 


### PR DESCRIPTION
My original idea of giving progress messages their own separate type and avoiding using an encoding for the event turned out to be a poor one, and httpx-sse has built-in support for decoding JSON messages. Switch to JSON encoding for progress messages, falling back on using the data verbatim if JSON encoding failed, contains unknown keys, or has an invalid progress value.