### PR TITLE
DM-38554: Tweak progress after spawn to 75%

### DIFF
--- a/src/rsp_restspawner/spawner.py
+++ b/src/rsp_restspawner/spawner.py
@@ -90,7 +90,7 @@ class SpawnEvent:
         data["progress"] = progress
 
         if sse.event == "complete":
-            data["progress"] = 90
+            data["progress"] = 75
             return cls(**data, severity="info", complete=True)
         elif sse.event in ("info", "error"):
             return cls(**data, severity=sse.event)
@@ -437,7 +437,7 @@ class RSPRestSpawner(Spawner):
             # if it really is running, and if so, return its URL.
             if r.status_code == 409:
                 event = SpawnEvent(
-                    progress=90, message="Lab already running", severity="info"
+                    progress=75, message="Lab already running", severity="info"
                 )
                 self._events.append(event)
                 return await self._get_internal_url()

--- a/tests/spawner_test.py
+++ b/tests/spawner_test.py
@@ -86,7 +86,7 @@ async def test_progress(spawner: RSPRestSpawner) -> None:
         {"progress": 2, "message": "[info] Lab creation initiated"},
         {"progress": 45, "message": "[info] Pod requested"},
         {
-            "progress": 90,
+            "progress": 75,
             "message": f"[info] Pod successfully spawned for {user}",
         },
     ]
@@ -108,7 +108,7 @@ async def test_progress_multiple(
         {"progress": 2, "message": "[info] Lab creation initiated"},
         {"progress": 45, "message": "[info] Pod requested"},
         {
-            "progress": 90,
+            "progress": 75,
             "message": f"[info] Pod successfully spawned for {user}",
         },
     ]


### PR DESCRIPTION
Subjectively, waiting for the lab process to start takes a fairly substantial amount of time. Give it the last 25% of the progress bar instead of only 10%.