### PR TITLE
DM-39400: Improve logging in spawner get_url method

### DIFF
--- a/src/rsp_restspawner/spawner.py
+++ b/src/rsp_restspawner/spawner.py
@@ -228,8 +228,21 @@ class RSPRestSpawner(Spawner):
         """
         try:
             return await self._get_internal_url()
+        except MissingFieldError:
+            # This is normal if the lab is currently being spawned or deleted
+            # when JupyterHub asks for its URL. Tell JupyterHub to use the
+            # stored URL.
+            msg = (
+                f"Lab for {self.user.name} has no URL (possibly still"
+                " spawning), falling back on stored URL"
+            )
+            self.log.info(msg)
+            return await super().get_url()
         except Exception:
-            msg = f"Unable to get URL of running lab for {self.user.name}"
+            msg = (
+                f"Unable to get URL of running lab for {self.user.name},"
+                " falling back on stored URL"
+            )
             self.log.exception(msg)
             return await super().get_url()
 


### PR DESCRIPTION
It's normal for retrieving the lab URL to raise MissingFieldError if the lab is still in the process of spawning. Handle that explicitly and log it only at info level. Use a better log message for get_url exceptions.