### PR TITLE
DM-40638: Update Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: update-deps
-update-deps:
-	pip install --upgrade pip-tools pip setuptools
-	pip-compile --upgrade --resolver=backtracking --build-isolation --allow-unsafe --generate-hashes --output-file requirements/main.txt requirements/main.in
-	pip-compile --upgrade --resolver=backtracking --build-isolation --allow-unsafe --generate-hashes --output-file requirements/dev.txt requirements/dev.in
+.PHONY: help
+help:
+	@echo "Make targets for RSP REST spawner"
+	@echo "make init - Set up dev environment"
+	@echo "make update - Update pinned dependencies and run make init"
+	@echo "make update-deps - Update pinned dependencies"
+	@echo "make update-deps-no-hashes - Pin dependencies without hashes"
 
 .PHONY: init
 init:
@@ -15,6 +17,23 @@ init:
 .PHONY: update
 update: update-deps init
 
-.PHONY: run
-run:
-	tox -e run
+.PHONY: update-deps
+update-deps:
+	pip install --upgrade pip-tools pip setuptools
+	pip-compile --upgrade --resolver=backtracking --build-isolation	\
+	    --allow-unsafe --generate-hashes				\
+	    --output-file requirements/main.txt requirements/main.in
+	pip-compile --upgrade --resolver=backtracking --build-isolation	\
+	    --allow-unsafe --generate-hashes				\
+	    --output-file requirements/dev.txt requirements/dev.in
+
+# Useful for testing against a Git version of Safir.
+.PHONY: update-deps-no-hashes
+update-deps-no-hashes:
+	pip install --upgrade pip-tools pip setuptools
+	pip-compile --upgrade --resolver=backtracking --build-isolation \
+	    --allow-unsafe						\
+	    --output-file requirements/main.txt requirements/main.in
+	pip-compile --upgrade --resolver=backtracking --build-isolation \
+	    --allow-unsafe						\
+	    --output-file requirements/dev.txt requirements/dev.in


### PR DESCRIPTION
Add the standard update-deps-no-hashes target and add a help target to the Makefile summarizing the available targets. Make that target the default.