### PR TITLE
DM-41350: Handle terminating and terminated status

### DIFF
--- a/tests/spawner_test.py
+++ b/tests/spawner_test.py
@@ -51,12 +51,14 @@ async def test_poll(
     spawner: RSPRestSpawner, mock_lab_controller: MockLabController
 ) -> None:
     assert await spawner.poll() == 0
-    mock_lab_controller.set_status(spawner.user.name, LabStatus.STARTING)
+    mock_lab_controller.set_status(spawner.user.name, LabStatus.PENDING)
     assert await spawner.poll() is None
     mock_lab_controller.set_status(spawner.user.name, LabStatus.RUNNING)
     assert await spawner.poll() is None
     mock_lab_controller.set_status(spawner.user.name, LabStatus.TERMINATING)
-    assert await spawner.poll() is None
+    assert await spawner.poll() == 0
+    mock_lab_controller.set_status(spawner.user.name, LabStatus.TERMINATED)
+    assert await spawner.poll() == 0
     mock_lab_controller.set_status(spawner.user.name, LabStatus.FAILED)
     assert await spawner.poll() == 1
     await spawner.stop()


### PR DESCRIPTION
Update the lab status enum to match the current Nublado controller, including renaming starting to pending. Add support for terminated status, which will be used for labs killed by the idle culler. Update comments for the (soon to be implemented) behavior of the Nublado controller.

Treat terminating status the same as terminated: tell the hub that the lab has exited, even though it hasn't yet. We want to allow the user to start spawning a new lab, and if they kick that off before the lab deletion completes, we'll join the existing delete call now that the controller supports multiple simultaneous deletes.